### PR TITLE
gcp: refactor label key and value sanitization

### DIFF
--- a/gcp.go
+++ b/gcp.go
@@ -6,11 +6,26 @@ import (
 	"maps"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var gcpLabelCharReplacer = strings.NewReplacer(
+	// slash and dot are common, use different replacement chars:
+	"/", "_", // replace slashes with underscores
+	".", "-", // replace dots with dashes
+
+	// less common characters, replace with dashes:
+	" ", "-", // replace spaces with dashes
+	":", "-", // replace colons with dashes
+	",", "-", // replace commas with dashes
+	";", "-", // replace semi-colons with dashes
+	"=", "-", // replace equals with dashes
+	"+", "-", // replace plus with dashes
 )
 
 type GCPClient interface {
@@ -172,38 +187,106 @@ func parseVolumeID(id string) (string, string, string, error) {
 	return project, location, name, nil
 }
 
-func sanitizeLabelsForGCP(labels map[string]string) map[string]string {
-	newLabels := make(map[string]string, len(labels))
-	for k, v := range labels {
-		newLabels[sanitizeKeyForGCP(k)] = sanitizeValueForGCP(v)
-	}
-	return newLabels
+// isValidGCPChar returns true if the rune is valid for GCP labels:
+// lowercase letters, numbers, dash, or underscore. International characters are
+// allowed.
+func isValidGCPChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_'
 }
 
-func sanitizeKeysForGCP(keys []string) []string {
-	newKeys := make([]string, len(keys))
-	for i, k := range keys {
-		newKeys[i] = sanitizeKeyForGCP(k)
+// sanitizeGCPLabelComponent handles the common sanitization logic for both keys
+// and values
+func sanitizeGCPLabelComponent(s string, isKey bool) string {
+	// Convert to lowercase
+	s = strings.ToLower(s)
+
+	// Replace invalid characters with dashes
+	s = gcpLabelCharReplacer.Replace(s)
+
+	// Filter to only valid characters
+	var b strings.Builder
+	for _, r := range s {
+		if isValidGCPChar(r) {
+			b.WriteRune(r)
+		}
 	}
-	return newKeys
+	s = b.String()
+
+	// For keys, ensure they start with a letter
+	if isKey && len(s) > 0 && !unicode.IsLetter(rune(s[0])) {
+		s = "k" + s
+	}
+
+	// Remove consecutive dashes/underscores
+	for strings.Contains(s, "--") || strings.Contains(s, "__") {
+		s = strings.ReplaceAll(s, "--", "-")
+		s = strings.ReplaceAll(s, "__", "_")
+	}
+
+	// Remove any trailing dashes or underscores
+	s = strings.TrimRight(s, "-_")
+
+	// Truncate to maximum length
+	if len(s) > 63 {
+		s = s[:63]
+		s = strings.TrimRight(s, "-_")
+	}
+
+	return s
 }
 
-// sanitizeKeyForGCP sanitizes a Kubernetes label key to fit GCP's label key constraints
+// sanitizeKeyForGCP sanitizes a Kubernetes label key to fit GCP's label key constraints:
+// - Must start with a lowercase letter or international character
+// - Can only contain lowercase letters, numbers, dashes and underscores
+// - Must be between 1 and 63 characters long
+// - Must use UTF-8 encoding
 func sanitizeKeyForGCP(key string) string {
-	key = strings.ToLower(key)
-	key = strings.NewReplacer("/", "_", ".", "-").Replace(key) // Replace disallowed characters
-	key = strings.TrimRight(key, "-_")                         // Ensure it does not end with '-' or '_'
-
-	if len(key) > 63 {
-		key = key[:63]
-	}
-	return key
+	return sanitizeGCPLabelComponent(key, true)
 }
 
-// sanitizeKeyForGCP sanitizes a Kubernetes label value to fit GCP's label value constraints
+// sanitizeValueForGCP sanitizes a Kubernetes label value to fit GCP's label value constraints:
+// - Can be empty
+// - Maximum length of 63 characters
+// - Can only contain lowercase letters, numbers, dashes and underscores
+// - Must use UTF-8 encoding
 func sanitizeValueForGCP(value string) string {
-	if len(value) > 63 {
-		value = value[:63]
+	return sanitizeGCPLabelComponent(value, false)
+}
+
+// sanitizeLabelsForGCP sanitizes a map of Kubernetes labels to fit GCP's constraints.
+// Empty keys after sanitization are dropped from the result.
+func sanitizeLabelsForGCP(labels map[string]string) map[string]string {
+	if len(labels) > 64 {
+		// If we have more than 64 labels, only take the first 64
+		truncatedLabels := make(map[string]string, 64)
+		i := 0
+		for k, v := range labels {
+			if i >= 64 {
+				break
+			}
+			truncatedLabels[k] = v
+			i++
+		}
+		labels = truncatedLabels
 	}
-	return value
+
+	result := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if sanitizedKey := sanitizeKeyForGCP(k); sanitizedKey != "" {
+			result[sanitizedKey] = sanitizeValueForGCP(v)
+		}
+	}
+	return result
+}
+
+// sanitizeKeysForGCP sanitizes a slice of label keys to fit GCP's constraints.
+// Empty keys after sanitization are dropped from the result.
+func sanitizeKeysForGCP(keys []string) []string {
+	result := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if sanitized := sanitizeKeyForGCP(k); sanitized != "" {
+			result = append(result, sanitized)
+		}
+	}
+	return result
 }

--- a/gcp_test.go
+++ b/gcp_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"maps"
-	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -155,54 +155,6 @@ func TestDeletePDVolumeLabels(t *testing.T) {
 	}
 }
 
-func TestSanitizeLabelsForGCP(t *testing.T) {
-	tests := []struct {
-		name   string
-		labels map[string]string
-		want   map[string]string
-	}{
-		{
-			name: "simple labels",
-			labels: map[string]string{
-				"Example/Key": "Example Value",
-				"Another.Key": "Another Value",
-			},
-			want: map[string]string{
-				"example_key": "Example Value",
-				"another-key": "Another Value",
-			},
-		},
-		{
-			name: "labels with special characters",
-			labels: map[string]string{
-				"Domain.com/Key":  "Value_1",
-				"Project.Version": "Version-1.2.3",
-			},
-			want: map[string]string{
-				"domain-com_key":  "Value_1",
-				"project-version": "Version-1.2.3",
-			},
-		},
-		{
-			name: "labels exceeding maximum length",
-			labels: map[string]string{
-				strings.Repeat("a", 70): strings.Repeat("b", 70),
-			},
-			want: map[string]string{
-				strings.Repeat("a", 63): strings.Repeat("b", 63),
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sanitizeLabelsForGCP(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("sanitizeLabelsForGCP(), got = %v, want = %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestParseVolumeID(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -252,6 +204,242 @@ func TestParseVolumeID(t *testing.T) {
 			}
 			if name != tt.wantName {
 				t.Errorf("Expected name %q, got %q", tt.wantName, name)
+			}
+		})
+	}
+}
+
+func TestSanitizeKeyForGCP(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "standard valid key",
+			key:  "app",
+			want: "app",
+		},
+		{
+			name: "uppercase converted to lowercase",
+			key:  "APP",
+			want: "app",
+		},
+		{
+			name: "must start with letter",
+			key:  "123-app",
+			want: "k123-app",
+		},
+		{
+			name: "replace invalid characters",
+			key:  "kubernetes.io/app=name:v1",
+			want: "kubernetes-io_app-name-v1",
+		},
+		{
+			name: "international characters preserved",
+			key:  "café-app",
+			want: "café-app",
+		},
+		{
+			name: "truncate long key",
+			key:  strings.Repeat("a", 70),
+			want: strings.Repeat("a", 63),
+		},
+		{
+			name: "collapse multiple separators",
+			key:  "app--name___test",
+			want: "app-name_test",
+		},
+		{
+			name: "trim trailing separators",
+			key:  "app-name---_",
+			want: "app-name",
+		},
+		{
+			name: "empty string",
+			key:  "",
+			want: "",
+		},
+		{
+			name: "only special characters",
+			key:  "!@#$%^&*()",
+			want: "",
+		},
+		{
+			name: "preserve underscores",
+			key:  "app_name_test",
+			want: "app_name_test",
+		},
+		{
+			name: "complex domain-style key",
+			key:  "k8s.io/persistent-volume/mount-path",
+			want: "k8s-io_persistent-volume_mount-path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeKeyForGCP(tt.key)
+			if got != tt.want {
+				t.Errorf("sanitizeKeyForGCP(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeValueForGCP(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "standard valid value",
+			value: "value-123",
+			want:  "value-123",
+		},
+		{
+			name:  "uppercase converted to lowercase",
+			value: "VALUE_123",
+			want:  "value_123",
+		},
+		{
+			name:  "special characters replaced",
+			value: "value.with:special/chars",
+			want:  "value-with-special-chars",
+		},
+		{
+			name:  "empty value allowed",
+			value: "",
+			want:  "",
+		},
+		{
+			name:  "truncate long value",
+			value: strings.Repeat("v", 70),
+			want:  strings.Repeat("v", 63),
+		},
+		{
+			name:  "collapse multiple separators",
+			value: "value--with___separators",
+			want:  "value-with_separators",
+		},
+		{
+			name:  "trim trailing separators",
+			value: "value-123---_",
+			want:  "value-123",
+		},
+		{
+			name:  "international characters preserved",
+			value: "café-123",
+			want:  "café-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeValueForGCP(tt.value)
+			if got != tt.want {
+				t.Errorf("sanitizeValueForGCP(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabelsForGCP(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name: "standard valid labels",
+			labels: map[string]string{
+				"app":    "nginx",
+				"env":    "prod",
+				"region": "us-east1",
+			},
+			want: map[string]string{
+				"app":    "nginx",
+				"env":    "prod",
+				"region": "us-east1",
+			},
+		},
+		{
+			name: "sanitize keys and values",
+			labels: map[string]string{
+				"Kubernetes.io/app": "NGINX-1.0",
+				"123-region":        "US-EAST1",
+			},
+			want: map[string]string{
+				"kubernetes-io-app": "nginx-1-0",
+				"k123-region":       "us-east1",
+			},
+		},
+		{
+			name: "handle empty values",
+			labels: map[string]string{
+				"app": "",
+				"env": "prod",
+				"":    "invalid",
+			},
+			want: map[string]string{
+				"app": "",
+				"env": "prod",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabelsForGCP(tt.labels)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("sanitizeLabelsForGCP() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSanitizeKeysForGCP(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []string
+		want []string
+	}{
+		{
+			name: "standard valid keys",
+			keys: []string{"app", "env", "region"},
+			want: []string{"app", "env", "region"},
+		},
+		{
+			name: "sanitize invalid keys",
+			keys: []string{
+				"Kubernetes.io/app",
+				"123-region",
+				"",
+				"!@#",
+			},
+			want: []string{
+				"kubernetes-io_app",
+				"k123-region",
+			},
+		},
+		{
+			name: "empty slice",
+			keys: []string{},
+			want: []string{},
+		},
+		{
+			name: "all invalid keys",
+			keys: []string{"", "!@#", "123"},
+			want: []string{"k123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeKeysForGCP(tt.keys)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("sanitizeKeysForGCP() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
The previous logic did not properly sanitize the label values, as it only ensured length was within the 64 char limit. However, there are additional restrictions on labels and they are similar to the key restrictions.

The language from the GCP docs is:

> Each resource can have up to 64 labels.
> Each label must be a key-value pair.
> Keys have a minimum length of 1 character and a maximum length of 63 characters, and cannot be empty. Values can be empty, and have a maximum length of 63 characters.
> Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes. All characters must use UTF-8 encoding, and international characters are allowed. Keys must start with a lowercase letter or international character.

The new logic attempts to follow all of these rules. The test cases have been expanded to reflect this as well.